### PR TITLE
Fix slider visibility not working on mobile

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,7 +35,8 @@ jQuery(document).ready(function($){
     function checkPosition(container) {
         container.each(function(){
             var actualContainer = $(this);
-            if( $(window).scrollTop() + $(window).height()*0.5 > actualContainer.offset().top) {
+            var rect = actualContainer[0].getBoundingClientRect();
+            if( rect.top >= 0 && rect.bottom <= (window.innerHeight || document.documentElement.clientHeight)) {
                 actualContainer.addClass('is-visible');
             }
         });


### PR DESCRIPTION
On some mobile devices that have a very wide aspect ratio, the slider will never be visible for the last image even if users scroll down entirely. Fixed it by changing `checkPosition()` to calculate visibility using `getBoundingClientRect()`.